### PR TITLE
Added .asciidoc file extension, converted line endings from /r to /n

### DIFF
--- a/AsciiDoc.tmLanguage
+++ b/AsciiDoc.tmLanguage
@@ -1,1 +1,706 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict>	<key>comment</key>	<string>		A very early hack. Mostly ripped from other syntaxes.		Only the very basic stuff is working.	</string>	<key>fileTypes</key>	<array>		<string>asc</string>	</array>	<key>foldingStartMarker</key>	<string>(?x)		(([/+-.*_=]){4,}		|&lt;!--(?!.*--&gt;)		)</string>	<key>foldingStopMarker</key>	<string>(?x)		(([/+-.*_=]){4,}		|^\s*--&gt;		)</string>	<key>keyEquivalent</key>	<string>^~A</string>	<key>name</key>	<string>AsciiDoc</string>	<key>patterns</key>	<array>		<dict>			<key>include</key>			<string>#heading_inline</string>		</dict>		<dict>			<key>include</key>			<string>#heading-block</string>		</dict>		<dict>			<key>include</key>			<string>#heading-blockattr</string>		</dict>		<dict>			<key>begin</key>			<string>\$\$(?!\$)</string>			<key>end</key>			<string>\$\$(?!\$)</string>			<key>name</key>			<string>comment.block.passthrough.macro.doubledollar.asciidoc</string>		</dict>		<dict>			<key>begin</key>			<string>\+\+\+(?!\+)</string>			<key>end</key>			<string>\+\+\+(?!\+)</string>			<key>name</key>			<string>comment.block.passthrough.macro.tripeplus.asciidoc</string>		</dict>		<dict>			<key>match</key>			<string>(//).*$\n?</string>			<key>name</key>			<string>comment.line.double-slash.asciidoc</string>		</dict>		<dict>			<key>begin</key>			<string>(?x)^				(?=	([/+-.*_=]{4,})\s*$				|	([ \t]{1,})				|	[=]{1,6}\s*+				|	[ ]{,3}(?&lt;marker&gt;[-*_])([ ]{,2}\k&lt;marker&gt;){2,}[ \t]*+$				)</string>			<key>end</key>			<string>(?x)^				(?!	\1				|	([ \t]{1,})				|	[=]{1,6}\s*+				|	[ ]{,3}(?&lt;marker&gt;[-*_])([ ]{,2}\k&lt;marker&gt;){2,}[ \t]*+$				)</string>			<key>name</key>			<string>meta.block-level.asciidoc</string>			<key>patterns</key>			<array>				<dict>					<key>include</key>					<string>#block_quote</string>				</dict>				<dict>					<key>include</key>					<string>#block_raw</string>				</dict>				<dict>					<key>include</key>					<string>#heading_inline</string>				</dict>				<dict>					<key>include</key>					<string>#heading-block</string>				</dict>				<dict>					<key>include</key>					<string>#separator</string>				</dict>			</array>		</dict>		<dict>			<key>begin</key>			<string>^[ ]{0,3}([*+-])(?=\s)</string>			<key>captures</key>			<dict>				<key>1</key>				<dict>					<key>name</key>					<string>punctuation.definition.list_item.asciidoc</string>				</dict>			</dict>			<key>end</key>			<string>^(?=\S)</string>			<key>name</key>			<string>markup.list.unnumbered.asciidoc</string>			<key>patterns</key>			<array>				<dict>					<key>include</key>					<string>#list-paragraph</string>				</dict>			</array>		</dict>		<dict>			<key>begin</key>			<string>^[ ]{0,3}[0-9]+(\.)(?=\s)</string>			<key>captures</key>			<dict>				<key>1</key>				<dict>					<key>name</key>					<string>punctuation.definition.list_item.asciidoc</string>				</dict>			</dict>			<key>end</key>			<string>^(?=\S)</string>			<key>name</key>			<string>markup.list.numbered.asciidoc</string>			<key>patterns</key>			<array>				<dict>					<key>include</key>					<string>#list-paragraph</string>				</dict>			</array>		</dict>		<dict>			<key>begin</key>			<string>^([/+-.*_=]){4,}\s*$</string>			<key>end</key>			<string>^\1{4,}\s*$</string>			<key>name</key>			<string>comment.block.asciidoc</string>		</dict>		<dict>			<key>begin</key>			<string>^([/+.]){4,}\s*$</string>			<key>comment</key>			<string>				asciidoc formatting is disabled inside certain blocks.			</string>			<key>end</key>			<string>^[/+.]{4,}\s*$</string>			<key>name</key>			<string>meta.disable-asciidoc</string>		</dict>		<dict>			<key>begin</key>			<string>^(?=\S)(?![=-]{3,}(?=$))(?!\.\S+)</string>			<key>end</key>			<string>^(?:\s*$|(?=[ ]{,3}&gt;.))|(?=[ \t]*\n)(?&lt;=^===|^====|=====|^---|^----|-----)[ \t]*\n</string>			<key>name</key>			<string>meta.paragraph.asciidoc</string>			<key>patterns</key>			<array>				<dict>					<key>include</key>					<string>#inline</string>				</dict>				<dict>					<key>include</key>					<string>text.basic</string>				</dict>				<dict>					<key>captures</key>					<dict>						<key>1</key>						<dict>							<key>name</key>							<string>punctuation.definition.heading.asciidoc</string>						</dict>					</dict>					<key>match</key>					<string>^(={3,})(?=[ \t]*$)</string>					<key>name</key>					<string>markup.heading.0.asciidoc</string>				</dict>				<dict>					<key>captures</key>					<dict>						<key>1</key>						<dict>							<key>name</key>							<string>punctuation.definition.heading.asciidoc</string>						</dict>					</dict>					<key>match</key>					<string>^(-{3,})(?=[ \t]*$)</string>					<key>name</key>					<string>markup.heading.1.asciidoc</string>				</dict>				<dict>					<key>captures</key>					<dict>						<key>1</key>						<dict>							<key>name</key>							<string>punctuation.definition.heading.asciidoc</string>						</dict>					</dict>					<key>match</key>					<string>^(~{3,})(?=[ \t]*$)</string>					<key>name</key>					<string>markup.heading.2.asciidoc</string>				</dict>				<dict>					<key>captures</key>					<dict>						<key>1</key>						<dict>							<key>name</key>							<string>punctuation.definition.heading.asciidoc</string>						</dict>					</dict>					<key>match</key>					<string>^(\^{3,})(?=[ \t]*$)</string>					<key>name</key>					<string>markup.heading.3.asciidoc</string>				</dict>				<dict>					<key>captures</key>					<dict>						<key>1</key>						<dict>							<key>name</key>							<string>punctuation.definition.heading.asciidoc</string>						</dict>					</dict>					<key>match</key>					<string>^(\+{3,})(?=[ \t]*$)</string>					<key>name</key>					<string>markup.heading.4.asciidoc</string>				</dict>			</array>		</dict>	</array>	<key>repository</key>	<dict>		<key>attribute-entry</key>		<dict>			<key>match</key>			<string>^:[-_. A-Za-z0-9]+:\s*(.*)\s*$</string>			<key>name</key>			<string>variable.other</string>		</dict>		<key>attribute-reference</key>		<dict>			<key>match</key>			<string>{[-_. A-Za-z0-9]+}</string>			<key>name</key>			<string>variable.other</string>		</dict>		<key>attribute-reference-predefined</key>		<dict>			<key>match</key>			<string>{(?i:amp|asciidoc-dir|asciidoc-file|asciidoc-version|author|authored|authorinitials|backend-docbook|backend-xhtml11|backend-html4|docbook-article|xhtml11-article|html4-article|docbook-book|xhtml11-book|html4-book|docbook-manpage|xhtml11-manpage|html4-manpage|backend|backslash|basebackend|brvbar|date|docdate|doctime|docname|docfile|docdir|doctitle|doctype-article|doctype-book|doctype-manpage|doctype|email|empty|encoding|filetype|firstname|gt|id|indir|infile|lastname|level|listindex|localdate|localtime|lt|manname|manpurpose|mantitle|manvolnum|middlename|nbsp|outdir|outfile|reftext|revision|sectnum|showcomments|title|two_colons|two_semicolons|user-dir|verbose)}</string>			<key>name</key>			<string>support.variable</string>		</dict>		<key>block_quote</key>		<dict>			<key>begin</key>			<string>^([/+-.*_=]){4,}\s*$</string>			<key>end</key>			<string>^\1{4,}\s*$</string>			<key>name</key>			<string>comment.block.asciidoc</string>		</dict>		<key>block_raw</key>		<dict>			<key>match</key>			<string>\G([ ]{4}|\t).*$\n?</string>			<key>name</key>			<string>markup.raw.block.asciidoc</string>		</dict>		<key>bracket</key>		<dict>			<key>comment</key>			<string>				asciidoc will convert this for us. We match it so that the				HTML grammar will not mark it up as invalid.			</string>			<key>match</key>			<string>&lt;(?![a-z/?\$!])</string>			<key>name</key>			<string>meta.other.valid-bracket.asciidoc</string>		</dict>		<key>character-replacements</key>		<dict>			<key>match</key>			<string>\(C\)|\(R\)|\(TM\)|--(?!-)|\.\.\.(?!\.)|-&gt;|&lt;-|=&gt;|&lt;=</string>			<key>name</key>			<string>constant.character.asciidoc</string>		</dict>		<key>escape</key>		<dict>			<key>match</key>			<string>\\[-`*_#+.!(){}\[\]\\&gt;:]</string>			<key>name</key>			<string>constant.character.escape.asciidoc</string>		</dict>		<key>heading</key>		<dict>			<key>captures</key>			<dict>				<key>1</key>				<dict>					<key>name</key>					<string>punctuation.definition.heading.asciidoc</string>				</dict>			</dict>			<key>contentName</key>			<string>entity.name.section.asciidoc</string>			<key>match</key>			<string>(?m)^(\S+)$([=-~^+])+\s*$</string>			<key>name</key>			<string>markup.heading.asciidoc</string>		</dict>		<key>heading-block</key>		<dict>			<key>captures</key>			<dict>				<key>1</key>				<dict>					<key>name</key>					<string>punctuation.definition.heading.asciidoc</string>				</dict>			</dict>			<key>match</key>			<string>^\.(\w.*)$</string>			<key>name</key>			<string>markup.heading.asciidoc</string>		</dict>		<key>heading-blockattr</key>		<dict>			<key>captures</key>			<dict>				<key>1</key>				<dict>					<key>name</key>					<string>punctuation.definition.heading.asciidoc</string>				</dict>			</dict>			<key>match</key>			<string>^\[\[?(\w.*)\]$</string>			<key>name</key>			<string>markup.heading.asciidoc</string>		</dict>		<key>heading_inline</key>		<dict>			<key>begin</key>			<string>\G(={1,6})(?!=)\s*(?=\S)</string>			<key>captures</key>			<dict>				<key>1</key>				<dict>					<key>name</key>					<string>punctuation.definition.heading.asciidoc</string>				</dict>			</dict>			<key>contentName</key>			<string>entity.name.section.asciidoc</string>			<key>end</key>			<string>\s*(=*)$\n?</string>			<key>name</key>			<string>markup.heading.asciidoc</string>			<key>patterns</key>			<array>				<dict>					<key>include</key>					<string>#inline</string>				</dict>			</array>		</dict>		<key>inline</key>		<dict>			<key>patterns</key>			<array>				<dict>					<key>include</key>					<string>#line-break</string>				</dict>				<dict>					<key>include</key>					<string>#line-page-break</string>				</dict>				<dict>					<key>include</key>					<string>#line-ruler</string>				</dict>				<dict>					<key>include</key>					<string>#escape</string>				</dict>				<dict>					<key>include</key>					<string>#passthrough-macro-trippleplus-inline</string>				</dict>				<dict>					<key>include</key>					<string>#passthrough-macro-doubledollar-inline</string>				</dict>				<dict>					<key>include</key>					<string>#character-replacements</string>				</dict>				<dict>					<key>include</key>					<string>#bracket</string>				</dict>				<dict>					<key>include</key>					<string>#raw</string>				</dict>				<dict>					<key>include</key>					<string>#text-quote-single</string>				</dict>				<dict>					<key>include</key>					<string>#text-quote-double</string>				</dict>				<dict>					<key>include</key>					<string>#text-quote-other</string>				</dict>				<dict>					<key>include</key>					<string>#text-bold-unconstrained</string>				</dict>				<dict>					<key>include</key>					<string>#text-italic-unconstrained</string>				</dict>				<dict>					<key>include</key>					<string>#text-monospace-unconstrained</string>				</dict>				<dict>					<key>include</key>					<string>#text-unquoted-unconstrained</string>				</dict>				<dict>					<key>include</key>					<string>#text-bold</string>				</dict>				<dict>					<key>include</key>					<string>#text-italic</string>				</dict>				<dict>					<key>include</key>					<string>#text-monospace</string>				</dict>				<dict>					<key>include</key>					<string>#text-unquoted</string>				</dict>				<dict>					<key>include</key>					<string>#attribute-entry</string>				</dict>				<dict>					<key>include</key>					<string>#attribute-reference-predefined</string>				</dict>				<dict>					<key>include</key>					<string>#attribute-reference</string>				</dict>			</array>		</dict>		<key>line-break</key>		<dict>			<key>match</key>			<string>(?&lt;=\S)\s+\+$</string>			<key>name</key>			<string>constant.character.escape.asciidoc</string>		</dict>		<key>line-page-break</key>		<dict>			<key>match</key>			<string>^&lt;{3,}$</string>			<key>name</key>			<string>constant.character.escape.asciidoc</string>		</dict>		<key>line-ruler</key>		<dict>			<key>match</key>			<string>^'{3,}$</string>			<key>name</key>			<string>constant.character.escape.asciidoc</string>		</dict>		<key>list-paragraph</key>		<dict>			<key>patterns</key>			<array>				<dict>					<key>begin</key>					<string>\G\s+(?=\S)</string>					<key>end</key>					<string>^\s*$</string>					<key>name</key>					<string>meta.paragraph.list.asciidoc</string>					<key>patterns</key>					<array>						<dict>							<key>include</key>							<string>#inline</string>						</dict>					</array>				</dict>			</array>		</dict>		<key>passthrough-macro-doubledollar-inline</key>		<dict>			<key>match</key>			<string>(?:\[.*\])?\$\$(?!\$).+\$\$(?!\$)</string>			<key>name</key>			<string>comment.block.passthrough.asciidoc</string>		</dict>		<key>passthrough-macro-trippleplus-inline</key>		<dict>			<key>match</key>			<string>(?:\[.*\])?\+\+\+(?!\+).+\+\+\+(?!\+)</string>			<key>name</key>			<string>comment.block.passthrough.asciidoc</string>		</dict>		<key>raw</key>		<dict>			<key>captures</key>			<dict>				<key>1</key>				<dict>					<key>name</key>					<string>punctuation.definition.raw.asciidoc</string>				</dict>				<key>3</key>				<dict>					<key>name</key>					<string>punctuation.definition.raw.asciidoc</string>				</dict>			</dict>			<key>match</key>			<string>(`+)([^`]|(?!(?&lt;!`)\1(?!`))`)*+(\1)</string>			<key>name</key>			<string>markup.raw.inline.asciidoc</string>		</dict>		<key>separator</key>		<dict>			<key>match</key>			<string>\G[ ]{,3}([-*_])([ ]{,2}\1){2,}[ \t]*$\n?</string>			<key>name</key>			<string>meta.separator.asciidoc</string>		</dict>		<key>text-bold</key>		<dict>			<key>begin</key>			<string>(?&lt;!\w)(\*)(?=\S)</string>			<key>captures</key>			<dict>				<key>1</key>				<dict>					<key>name</key>					<string>punctuation.definition.bold.asciidoc</string>				</dict>			</dict>			<key>end</key>			<string>(?&lt;=\S)(\1)(?!\w)</string>			<key>name</key>			<string>markup.bold.asciidoc</string>		</dict>		<key>text-bold-unconstrained</key>		<dict>			<key>begin</key>			<string>(\*\*)(?=\S)</string>			<key>captures</key>			<dict>				<key>1</key>				<dict>					<key>name</key>					<string>punctuation.definition.bold.asciidoc</string>				</dict>			</dict>			<key>end</key>			<string>(?&lt;=\S)(\1)</string>			<key>name</key>			<string>markup.bold.asciidoc</string>		</dict>		<key>text-italic</key>		<dict>			<key>begin</key>			<string>(?&lt;!\w)('|_)(?=\S)</string>			<key>captures</key>			<dict>				<key>1</key>				<dict>					<key>name</key>					<string>punctuation.definition.italic.asciidoc</string>				</dict>			</dict>			<key>end</key>			<string>(?&lt;=\S)(\1)((?!\1)|(?=\1\1))(?!\w)</string>			<key>name</key>			<string>markup.italic.asciidoc</string>		</dict>		<key>text-italic-unconstrained</key>		<dict>			<key>begin</key>			<string>(__)(?=\S)</string>			<key>captures</key>			<dict>				<key>1</key>				<dict>					<key>name</key>					<string>punctuation.definition.italic.asciidoc</string>				</dict>			</dict>			<key>end</key>			<string>(?&lt;=\S)(\1)</string>			<key>name</key>			<string>markup.italic.asciidoc</string>		</dict>		<key>text-monospace</key>		<dict>			<key>match</key>			<string>(?&lt;!\w)([\+`])[^\+`]*(\1)(?!\w)</string>			<key>name</key>			<string>string.interpolated.asciidoc</string>		</dict>		<key>text-monospace-unconstrained</key>		<dict>			<key>match</key>			<string>(\+\+).*(\1)</string>			<key>name</key>			<string>string.interpolated.asciidoc</string>		</dict>		<key>text-quote-double</key>		<dict>			<key>match</key>			<string>(?&lt;!\w)(?:\[.*\])?``(?!`).*''(?!')(?!\w)</string>			<key>name</key>			<string>string.quoted.double.asciidoc</string>		</dict>		<key>text-quote-other</key>		<dict>			<key>match</key>			<string>(?&lt;!\w)(?:\[.*\])?([~^]).*(\1)(?!\w)</string>			<key>name</key>			<string>string.quoted.single.asciidoc</string>		</dict>		<key>text-quote-single</key>		<dict>			<key>comment</key>			<string>TODO: Sub- and Superscript are really unconstrained</string>			<key>match</key>			<string>(?&lt;!\w)(?:\[.*\])?`(?!`).*'(?!')(?!\w)</string>			<key>name</key>			<string>string.quoted.single.asciidoc</string>		</dict>		<key>text-unquoted</key>		<dict>			<key>match</key>			<string>(?&lt;!\w)(#).*(\1)(?!\w)</string>			<key>name</key>			<string>string.unquoted.asciidoc</string>		</dict>		<key>text-unquoted-unconstrained</key>		<dict>			<key>match</key>			<string>(##).*(\1)</string>			<key>name</key>			<string>string.unquoted.asciidoc</string>		</dict>	</dict>	<key>scopeName</key>	<string>text.asciidoc</string>	<key>uuid</key>	<string>090F38B8-2CEB-4956-A627-E24C7AA16ED6</string></dict></plist>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>comment</key>
+	<string>
+		A very early hack. Mostly ripped from other syntaxes.
+		Only the very basic stuff is working.
+	</string>
+	<key>fileTypes</key>
+	<array>
+		<string>asc</string>
+		<string>asciidoc</string>
+	</array>
+	<key>foldingStartMarker</key>
+	<string>(?x)
+		(([/+-.*_=]){4,}
+		|&lt;!--(?!.*--&gt;)
+		)</string>
+	<key>foldingStopMarker</key>
+	<string>(?x)
+		(([/+-.*_=]){4,}
+		|^\s*--&gt;
+		)</string>
+	<key>keyEquivalent</key>
+	<string>^~A</string>
+	<key>name</key>
+	<string>AsciiDoc</string>
+	<key>patterns</key>
+	<array>
+		<dict>
+			<key>include</key>
+			<string>#heading_inline</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#heading-block</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#heading-blockattr</string>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>\$\$(?!\$)</string>
+			<key>end</key>
+			<string>\$\$(?!\$)</string>
+			<key>name</key>
+			<string>comment.block.passthrough.macro.doubledollar.asciidoc</string>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>\+\+\+(?!\+)</string>
+			<key>end</key>
+			<string>\+\+\+(?!\+)</string>
+			<key>name</key>
+			<string>comment.block.passthrough.macro.tripeplus.asciidoc</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>(//).*$\n?</string>
+			<key>name</key>
+			<string>comment.line.double-slash.asciidoc</string>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>(?x)^
+				(?=	([/+-.*_=]{4,})\s*$
+				|	([ \t]{1,})
+				|	[=]{1,6}\s*+
+				|	[ ]{,3}(?&lt;marker&gt;[-*_])([ ]{,2}\k&lt;marker&gt;){2,}[ \t]*+$
+				)</string>
+			<key>end</key>
+			<string>(?x)^
+				(?!	\1
+				|	([ \t]{1,})
+				|	[=]{1,6}\s*+
+				|	[ ]{,3}(?&lt;marker&gt;[-*_])([ ]{,2}\k&lt;marker&gt;){2,}[ \t]*+$
+				)</string>
+			<key>name</key>
+			<string>meta.block-level.asciidoc</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#block_quote</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#block_raw</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#heading_inline</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#heading-block</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#separator</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>^[ ]{0,3}([*+-])(?=\s)</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.list_item.asciidoc</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>^(?=\S)</string>
+			<key>name</key>
+			<string>markup.list.unnumbered.asciidoc</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#list-paragraph</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>^[ ]{0,3}[0-9]+(\.)(?=\s)</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.list_item.asciidoc</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>^(?=\S)</string>
+			<key>name</key>
+			<string>markup.list.numbered.asciidoc</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#list-paragraph</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>^([/+-.*_=]){4,}\s*$</string>
+			<key>end</key>
+			<string>^\1{4,}\s*$</string>
+			<key>name</key>
+			<string>comment.block.asciidoc</string>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>^([/+.]){4,}\s*$</string>
+			<key>comment</key>
+			<string>
+				asciidoc formatting is disabled inside certain blocks.
+			</string>
+			<key>end</key>
+			<string>^[/+.]{4,}\s*$</string>
+			<key>name</key>
+			<string>meta.disable-asciidoc</string>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>^(?=\S)(?![=-]{3,}(?=$))(?!\.\S+)</string>
+			<key>end</key>
+			<string>^(?:\s*$|(?=[ ]{,3}&gt;.))|(?=[ \t]*\n)(?&lt;=^===|^====|=====|^---|^----|-----)[ \t]*\n</string>
+			<key>name</key>
+			<string>meta.paragraph.asciidoc</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#inline</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>text.basic</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.heading.asciidoc</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>^(={3,})(?=[ \t]*$)</string>
+					<key>name</key>
+					<string>markup.heading.0.asciidoc</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.heading.asciidoc</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>^(-{3,})(?=[ \t]*$)</string>
+					<key>name</key>
+					<string>markup.heading.1.asciidoc</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.heading.asciidoc</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>^(~{3,})(?=[ \t]*$)</string>
+					<key>name</key>
+					<string>markup.heading.2.asciidoc</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.heading.asciidoc</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>^(\^{3,})(?=[ \t]*$)</string>
+					<key>name</key>
+					<string>markup.heading.3.asciidoc</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.heading.asciidoc</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>^(\+{3,})(?=[ \t]*$)</string>
+					<key>name</key>
+					<string>markup.heading.4.asciidoc</string>
+				</dict>
+			</array>
+		</dict>
+	</array>
+	<key>repository</key>
+	<dict>
+		<key>attribute-entry</key>
+		<dict>
+			<key>match</key>
+			<string>^:[-_. A-Za-z0-9]+:\s*(.*)\s*$</string>
+			<key>name</key>
+			<string>variable.other</string>
+		</dict>
+		<key>attribute-reference</key>
+		<dict>
+			<key>match</key>
+			<string>{[-_. A-Za-z0-9]+}</string>
+			<key>name</key>
+			<string>variable.other</string>
+		</dict>
+		<key>attribute-reference-predefined</key>
+		<dict>
+			<key>match</key>
+			<string>{(?i:amp|asciidoc-dir|asciidoc-file|asciidoc-version|author|authored|authorinitials|backend-docbook|backend-xhtml11|backend-html4|docbook-article|xhtml11-article|html4-article|docbook-book|xhtml11-book|html4-book|docbook-manpage|xhtml11-manpage|html4-manpage|backend|backslash|basebackend|brvbar|date|docdate|doctime|docname|docfile|docdir|doctitle|doctype-article|doctype-book|doctype-manpage|doctype|email|empty|encoding|filetype|firstname|gt|id|indir|infile|lastname|level|listindex|localdate|localtime|lt|manname|manpurpose|mantitle|manvolnum|middlename|nbsp|outdir|outfile|reftext|revision|sectnum|showcomments|title|two_colons|two_semicolons|user-dir|verbose)}</string>
+			<key>name</key>
+			<string>support.variable</string>
+		</dict>
+		<key>block_quote</key>
+		<dict>
+			<key>begin</key>
+			<string>^([/+-.*_=]){4,}\s*$</string>
+			<key>end</key>
+			<string>^\1{4,}\s*$</string>
+			<key>name</key>
+			<string>comment.block.asciidoc</string>
+		</dict>
+		<key>block_raw</key>
+		<dict>
+			<key>match</key>
+			<string>\G([ ]{4}|\t).*$\n?</string>
+			<key>name</key>
+			<string>markup.raw.block.asciidoc</string>
+		</dict>
+		<key>bracket</key>
+		<dict>
+			<key>comment</key>
+			<string>
+				asciidoc will convert this for us. We match it so that the
+				HTML grammar will not mark it up as invalid.
+			</string>
+			<key>match</key>
+			<string>&lt;(?![a-z/?\$!])</string>
+			<key>name</key>
+			<string>meta.other.valid-bracket.asciidoc</string>
+		</dict>
+		<key>character-replacements</key>
+		<dict>
+			<key>match</key>
+			<string>\(C\)|\(R\)|\(TM\)|--(?!-)|\.\.\.(?!\.)|-&gt;|&lt;-|=&gt;|&lt;=</string>
+			<key>name</key>
+			<string>constant.character.asciidoc</string>
+		</dict>
+		<key>escape</key>
+		<dict>
+			<key>match</key>
+			<string>\\[-`*_#+.!(){}\[\]\\&gt;:]</string>
+			<key>name</key>
+			<string>constant.character.escape.asciidoc</string>
+		</dict>
+		<key>heading</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.heading.asciidoc</string>
+				</dict>
+			</dict>
+			<key>contentName</key>
+			<string>entity.name.section.asciidoc</string>
+			<key>match</key>
+			<string>(?m)^(\S+)$([=-~^+])+\s*$</string>
+			<key>name</key>
+			<string>markup.heading.asciidoc</string>
+		</dict>
+		<key>heading-block</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.heading.asciidoc</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>^\.(\w.*)$</string>
+			<key>name</key>
+			<string>markup.heading.asciidoc</string>
+		</dict>
+		<key>heading-blockattr</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.heading.asciidoc</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>^\[\[?(\w.*)\]$</string>
+			<key>name</key>
+			<string>markup.heading.asciidoc</string>
+		</dict>
+		<key>heading_inline</key>
+		<dict>
+			<key>begin</key>
+			<string>\G(={1,6})(?!=)\s*(?=\S)</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.heading.asciidoc</string>
+				</dict>
+			</dict>
+			<key>contentName</key>
+			<string>entity.name.section.asciidoc</string>
+			<key>end</key>
+			<string>\s*(=*)$\n?</string>
+			<key>name</key>
+			<string>markup.heading.asciidoc</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#inline</string>
+				</dict>
+			</array>
+		</dict>
+		<key>inline</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#line-break</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#line-page-break</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#line-ruler</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#escape</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#passthrough-macro-trippleplus-inline</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#passthrough-macro-doubledollar-inline</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#character-replacements</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#bracket</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#raw</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#text-quote-single</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#text-quote-double</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#text-quote-other</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#text-bold-unconstrained</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#text-italic-unconstrained</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#text-monospace-unconstrained</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#text-unquoted-unconstrained</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#text-bold</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#text-italic</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#text-monospace</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#text-unquoted</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#attribute-entry</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#attribute-reference-predefined</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#attribute-reference</string>
+				</dict>
+			</array>
+		</dict>
+		<key>line-break</key>
+		<dict>
+			<key>match</key>
+			<string>(?&lt;=\S)\s+\+$</string>
+			<key>name</key>
+			<string>constant.character.escape.asciidoc</string>
+		</dict>
+		<key>line-page-break</key>
+		<dict>
+			<key>match</key>
+			<string>^&lt;{3,}$</string>
+			<key>name</key>
+			<string>constant.character.escape.asciidoc</string>
+		</dict>
+		<key>line-ruler</key>
+		<dict>
+			<key>match</key>
+			<string>^'{3,}$</string>
+			<key>name</key>
+			<string>constant.character.escape.asciidoc</string>
+		</dict>
+		<key>list-paragraph</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>\G\s+(?=\S)</string>
+					<key>end</key>
+					<string>^\s*$</string>
+					<key>name</key>
+					<string>meta.paragraph.list.asciidoc</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#inline</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
+		<key>passthrough-macro-doubledollar-inline</key>
+		<dict>
+			<key>match</key>
+			<string>(?:\[.*\])?\$\$(?!\$).+\$\$(?!\$)</string>
+			<key>name</key>
+			<string>comment.block.passthrough.asciidoc</string>
+		</dict>
+		<key>passthrough-macro-trippleplus-inline</key>
+		<dict>
+			<key>match</key>
+			<string>(?:\[.*\])?\+\+\+(?!\+).+\+\+\+(?!\+)</string>
+			<key>name</key>
+			<string>comment.block.passthrough.asciidoc</string>
+		</dict>
+		<key>raw</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.raw.asciidoc</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.raw.asciidoc</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>(`+)([^`]|(?!(?&lt;!`)\1(?!`))`)*+(\1)</string>
+			<key>name</key>
+			<string>markup.raw.inline.asciidoc</string>
+		</dict>
+		<key>separator</key>
+		<dict>
+			<key>match</key>
+			<string>\G[ ]{,3}([-*_])([ ]{,2}\1){2,}[ \t]*$\n?</string>
+			<key>name</key>
+			<string>meta.separator.asciidoc</string>
+		</dict>
+		<key>text-bold</key>
+		<dict>
+			<key>begin</key>
+			<string>(?&lt;!\w)(\*)(?=\S)</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.bold.asciidoc</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(?&lt;=\S)(\1)(?!\w)</string>
+			<key>name</key>
+			<string>markup.bold.asciidoc</string>
+		</dict>
+		<key>text-bold-unconstrained</key>
+		<dict>
+			<key>begin</key>
+			<string>(\*\*)(?=\S)</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.bold.asciidoc</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(?&lt;=\S)(\1)</string>
+			<key>name</key>
+			<string>markup.bold.asciidoc</string>
+		</dict>
+		<key>text-italic</key>
+		<dict>
+			<key>begin</key>
+			<string>(?&lt;!\w)('|_)(?=\S)</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.italic.asciidoc</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(?&lt;=\S)(\1)((?!\1)|(?=\1\1))(?!\w)</string>
+			<key>name</key>
+			<string>markup.italic.asciidoc</string>
+		</dict>
+		<key>text-italic-unconstrained</key>
+		<dict>
+			<key>begin</key>
+			<string>(__)(?=\S)</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.italic.asciidoc</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(?&lt;=\S)(\1)</string>
+			<key>name</key>
+			<string>markup.italic.asciidoc</string>
+		</dict>
+		<key>text-monospace</key>
+		<dict>
+			<key>match</key>
+			<string>(?&lt;!\w)([\+`])[^\+`]*(\1)(?!\w)</string>
+			<key>name</key>
+			<string>string.interpolated.asciidoc</string>
+		</dict>
+		<key>text-monospace-unconstrained</key>
+		<dict>
+			<key>match</key>
+			<string>(\+\+).*(\1)</string>
+			<key>name</key>
+			<string>string.interpolated.asciidoc</string>
+		</dict>
+		<key>text-quote-double</key>
+		<dict>
+			<key>match</key>
+			<string>(?&lt;!\w)(?:\[.*\])?``(?!`).*''(?!')(?!\w)</string>
+			<key>name</key>
+			<string>string.quoted.double.asciidoc</string>
+		</dict>
+		<key>text-quote-other</key>
+		<dict>
+			<key>match</key>
+			<string>(?&lt;!\w)(?:\[.*\])?([~^]).*(\1)(?!\w)</string>
+			<key>name</key>
+			<string>string.quoted.single.asciidoc</string>
+		</dict>
+		<key>text-quote-single</key>
+		<dict>
+			<key>comment</key>
+			<string>TODO: Sub- and Superscript are really unconstrained</string>
+			<key>match</key>
+			<string>(?&lt;!\w)(?:\[.*\])?`(?!`).*'(?!')(?!\w)</string>
+			<key>name</key>
+			<string>string.quoted.single.asciidoc</string>
+		</dict>
+		<key>text-unquoted</key>
+		<dict>
+			<key>match</key>
+			<string>(?&lt;!\w)(#).*(\1)(?!\w)</string>
+			<key>name</key>
+			<string>string.unquoted.asciidoc</string>
+		</dict>
+		<key>text-unquoted-unconstrained</key>
+		<dict>
+			<key>match</key>
+			<string>(##).*(\1)</string>
+			<key>name</key>
+			<string>string.unquoted.asciidoc</string>
+		</dict>
+	</dict>
+	<key>scopeName</key>
+	<string>text.asciidoc</string>
+	<key>uuid</key>
+	<string>090F38B8-2CEB-4956-A627-E24C7AA16ED6</string>
+</dict>
+</plist>


### PR DESCRIPTION
I just wanted to send a simple PR to add the .asciidoc extension. However, the /r line endings made git diffs impossible, both in the web client and the terminal, as you can see in the diff here as well (the old file appears all in one line) so I converted them to the more standard /n.

Thanks for making this!
